### PR TITLE
Bhalsey/903 1784 ux escape tab behavior

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2014-2023, Inversoft Inc., All Rights Reserved
  */
-savantVersion = "2.0.0-RC.6"
+savantVersion = "2.0.0-RC.7"
 
-project(group: "org.inversoft.prime", name: "prime.js", version: "1.6.5", licenses: ["ApacheV2_0"]) {
+project(group: "org.inversoft.prime", name: "prime.js", version: "1.7.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/build.savant
+++ b/build.savant
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2014-2022, Inversoft Inc., All Rights Reserved
  */
-savantVersion = "1.0.0"
+savantVersion = "2.0.0-RC.6"
 
-project(group: "org.inversoft.prime", name: "prime.js", version: "1.6.4", licenses: ["ApacheV2_0"]) {
+project(group: "org.inversoft.prime", name: "prime.js", version: "1.6.5", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2023, Inversoft Inc., All Rights Reserved
  */
 savantVersion = "2.0.0-RC.6"
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2017-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,6 +137,6 @@ function test(callback, slow) {
             'src/test/css/Widgets.*.css',
             {pattern: 'src/test/html/*', watched: true, served: true, included: false}
           ]
-        }, callback()).start();
+        }, callback).start();
       }, callback);
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,6 +137,6 @@ function test(callback, slow) {
             'src/test/css/Widgets.*.css',
             {pattern: 'src/test/html/*', watched: true, served: true, included: false}
           ]
-        }, callback).start();
+        }, callback()).start();
       }, callback);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prime.js",
-  "version": "1.6.5",
+  "version": "1.7.0",
   "description": "Internal javascript library used by Inversoft",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prime.js",
-  "version": "1.4.3",
+  "version": "1.6.5",
   "description": "Internal javascript library used by Inversoft",
   "license": "Apache-2.0",
   "devDependencies": {

--- a/src/main/js/Widgets/AJAXDialog.js
+++ b/src/main/js/Widgets/AJAXDialog.js
@@ -43,11 +43,18 @@ class AJAXDialog {
    * @returns {AJAXDialog} This.
    */
   close() {
+    if (this.element === null) {
+      return;
+    }
+
     this.element.removeClass('open');
     if (this.draggable !== null) {
       this.draggable.destroy();
       this.draggable = null;
     }
+
+    document.removeEventListener('keydown', this._handleKeyDown);
+    document.removeEventListener('click', this._handleClick);
 
     setTimeout(function() {
       this.element.removeFromDOM();
@@ -343,10 +350,27 @@ class AJAXDialog {
         .go();
   }
 
+  _handleClick(event) {
+    if (event.target === Overlay.instance.overlay.domElement) {
+      Utils.stopEvent(event);
+      this.close();
+    }
+  }
+
+  _handleKeyDown(event) {
+    if (event.key === 'Escape') {
+      Utils.stopEvent(event);
+      this.close();
+    }
+  }
+
   _initializeDialog() {
     this.element.query(this.options.closeButtonElementSelector).each(function(e) {
       e.addEventListener('click', this._handleCloseClickEvent);
     }.bind(this));
+
+    document.addEventListener('keydown', this._handleKeyDown);
+    document.addEventListener('click', this._handleClick);
 
     // Only set the z-index upon first open
     if (!this.initialized) {

--- a/src/main/js/Widgets/AJAXDialog.js
+++ b/src/main/js/Widgets/AJAXDialog.js
@@ -27,11 +27,13 @@ class AJAXDialog {
   /**
    * Constructs a new dialog box, which is dynamically built and then populated with the HTML returned from an AJAX call.
    *
+   * @param {boolean} dismissible Whether dialog is easily dismissible by clicking outside dialog or pressing escape. Defaults to true.
    * @constructor
    */
-  constructor() {
+  constructor(dismissible = true) {
     Utils.bindAll(this);
 
+    this.dismissible = dismissible;
     this.draggable = null;
     this.element = null;
     this.initialized = false;
@@ -352,7 +354,7 @@ class AJAXDialog {
 
   _handleClick(event) {
     if (event.target === Overlay.instance.overlay.domElement) {
-      if (this._isTopDialog()) {
+      if (this._isTopDialog() && this.dismissible) {
         Utils.stopEvent(event);
         this.close();
       }
@@ -361,7 +363,7 @@ class AJAXDialog {
 
   _handleKeyDown(event) {
     if (this._isTopDialog()) {
-      if (event.key === 'Escape') {
+      if (event.key === 'Escape' && this.dismissible) {
         Utils.stopEvent(event);
         this.close();
       }

--- a/src/main/js/Widgets/AJAXDialog.js
+++ b/src/main/js/Widgets/AJAXDialog.js
@@ -210,7 +210,7 @@ class AJAXDialog {
    * @param dismissible {boolean} Whether dialog is dismissible.  Default option is true.
    * @returns {AJAXDialog} This.
    */
-  withDismissible(dismissible){
+  withDismissible(dismissible) {
     this.options.dismissible = dismissible;
     return this;
   }
@@ -362,20 +362,20 @@ class AJAXDialog {
   }
 
   _handleClick(event) {
-    if (event.target === Overlay.instance.overlay.domElement) {
-      if (this._isTopDialog() && this.options.dismissible) {
-        Utils.stopEvent(event);
-        this.close();
-      }
+    if (event.target === Overlay.instance.overlay.domElement &&
+        this._isTopDialog() &&
+        this.options.dismissible) {
+      Utils.stopEvent(event);
+      this.close();
     }
   }
 
   _handleKeyDown(event) {
-    if (this._isTopDialog()) {
-      if (event.key === 'Escape' && this.options.dismissible) {
-        Utils.stopEvent(event);
-        this.close();
-      }
+    if (this._isTopDialog() &&
+        event.key === 'Escape' &&
+        this.options.dismissible) {
+      Utils.stopEvent(event);
+      this.close();
     }
   }
 
@@ -384,8 +384,10 @@ class AJAXDialog {
       e.addEventListener('click', this._handleCloseClickEvent);
     }.bind(this));
 
-    document.addEventListener('keydown', this._handleKeyDown);
-    document.addEventListener('click', this._handleClick);
+    if (this.options.dismissible) {
+      document.addEventListener('keydown', this._handleKeyDown);
+      document.addEventListener('click', this._handleClick);
+    }
 
     // Only set the z-index upon first open
     if (!this.initialized) {

--- a/src/main/js/Widgets/AJAXDialog.js
+++ b/src/main/js/Widgets/AJAXDialog.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2017-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/js/Widgets/AJAXDialog.js
+++ b/src/main/js/Widgets/AJAXDialog.js
@@ -352,15 +352,19 @@ class AJAXDialog {
 
   _handleClick(event) {
     if (event.target === Overlay.instance.overlay.domElement) {
-      Utils.stopEvent(event);
-      this.close();
+      if (this._isTopDialog()) {
+        Utils.stopEvent(event);
+        this.close();
+      }
     }
   }
 
   _handleKeyDown(event) {
-    if (event.key === 'Escape') {
-      Utils.stopEvent(event);
-      this.close();
+    if (this._isTopDialog()) {
+      if (event.key === 'Escape') {
+        Utils.stopEvent(event);
+        this.close();
+      }
     }
   }
 
@@ -403,6 +407,12 @@ class AJAXDialog {
     }
 
     this.initialized = true;
+  }
+
+  _isTopDialog() {
+    const highestZIndex = this._determineZIndex();
+    const zIndex = parseInt(this.element.getComputedStyle()['zIndex']);
+    return (zIndex === highestZIndex);
   }
 
   /**

--- a/src/main/js/Widgets/AJAXDialog.js
+++ b/src/main/js/Widgets/AJAXDialog.js
@@ -27,13 +27,11 @@ class AJAXDialog {
   /**
    * Constructs a new dialog box, which is dynamically built and then populated with the HTML returned from an AJAX call.
    *
-   * @param {boolean} dismissible Whether dialog is easily dismissible by clicking outside dialog or pressing escape. Defaults to true.
    * @constructor
    */
-  constructor(dismissible = true) {
+  constructor() {
     Utils.bindAll(this);
 
-    this.dismissible = dismissible;
     this.draggable = null;
     this.element = null;
     this.initialized = false;
@@ -207,6 +205,17 @@ class AJAXDialog {
   }
 
   /**
+   * Sets whether this dialog is dismissible by clicking off it or hitting Escape
+   *
+   * @param dismissible {boolean} Whether dialog is dismissible.  Default option is true.
+   * @returns {AJAXDialog} This.
+   */
+  withDismissible(dismissible){
+    this.options.dismissible = dismissible;
+    return this;
+  }
+
+  /**
    * Sets the draggable element selector that is used for the DraggableWidget.
    *
    * @param selector {string} The element selector.
@@ -354,7 +363,7 @@ class AJAXDialog {
 
   _handleClick(event) {
     if (event.target === Overlay.instance.overlay.domElement) {
-      if (this._isTopDialog() && this.dismissible) {
+      if (this._isTopDialog() && this.options.dismissible) {
         Utils.stopEvent(event);
         this.close();
       }
@@ -363,7 +372,7 @@ class AJAXDialog {
 
   _handleKeyDown(event) {
     if (this._isTopDialog()) {
-      if (event.key === 'Escape' && this.dismissible) {
+      if (event.key === 'Escape' && this.options.dismissible) {
         Utils.stopEvent(event);
         this.close();
       }
@@ -430,6 +439,7 @@ class AJAXDialog {
       className: 'prime-dialog',
       closeButtonElementSelector: '[data-dialog-role="close-button"]',
       closeTimeout: 200,
+      dismissible: true,
       draggableElementSelector: '[data-dialog-role="draggable"]',
       formErrorCallback: null,
       formHandling: false,

--- a/src/main/js/Widgets/Searcher.js
+++ b/src/main/js/Widgets/Searcher.js
@@ -224,6 +224,7 @@ class Searcher {
     this.inputElement
         .addEventListener('blur', this._handleBlurEvent)
         .addEventListener('click', this._handleClickEvent)
+        .addEventListener('input', this._handleInputEvent)
         .addEventListener('keyup', this._handleKeyUpEvent)
         .addEventListener('keydown', this._handleKeyDownEvent)
         .addEventListener('focus', this._handleFocusEvent);
@@ -506,6 +507,15 @@ class Searcher {
   }
 
   /**
+   * Handle when we get new input in the field
+   *
+   * @private
+   */
+  _handleInputEvent() {
+    this.search();
+  }
+
+  /**
    * Handles the key down events that should not be propagated.
    *
    * @param {KeyboardEvent} event The keyboard event object.
@@ -527,6 +537,8 @@ class Searcher {
       }
     } else if (key === Events.Keys.ENTER) {
       Utils.stopEvent(event); // Don't bubble enter otherwise the form submits
+    } else if (key === Events.Keys.TAB && this.isSearchResultsVisible()) {
+      Utils.stopEvent(event); // Don't bubble tab otherwise value lost on tab focus
     }
   }
 
@@ -554,9 +566,10 @@ class Searcher {
       }
     } else if (key === Events.Keys.ESCAPE) {
       this.closeSearchResults();
-    } else if (key === Events.Keys.SPACE || key === Events.Keys.DELETE ||
-        (key >= 48 && key <= 90) || (key >= 96 && key <= 111) || (key >= 186 && key <= 192) || (key >= 219 && key <= 222)) {
-      this.search();
+    } else if (key === Events.Keys.TAB && this.getHighlightedSearchResult() !== null) {
+      // don't advance form field focus and add search result
+      Utils.stopEvent(event);
+      this.selectHighlightedSearchResult();
     }
   }
 

--- a/src/main/js/Widgets/Searcher.js
+++ b/src/main/js/Widgets/Searcher.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/html/test-functional.html
+++ b/src/test/html/test-functional.html
@@ -185,8 +185,8 @@
       var openFunction = function(e) {
         new Prime.Widgets.AJAXDialog()
             .withCallback(function(dialog) {
-              dialog.queryFirst('a.dialog-button').addEventListener('click', openFunction);
-              new Prime.Widgets.Tooltip(dialog.queryFirst('p'));
+              dialog.element.queryFirst('a.dialog-button').addEventListener('click', openFunction);
+              new Prime.Widgets.Tooltip(dialog.element.queryFirst('p'));
             })
             .initialize()
             .open('ajax-dialog-response.html');

--- a/src/test/html/test-functional.html
+++ b/src/test/html/test-functional.html
@@ -194,6 +194,20 @@
       };
 
       Prime.Document.queryById('ajax-dialog-button').addEventListener('click', openFunction);
+
+      var openNonDismissibleFunction = function(e) {
+        new Prime.Widgets.AJAXDialog(false)
+            .withCallback(function(dialog) {
+              dialog.element.queryFirst('a.dialog-button').addEventListener('click', openNonDismissibleFunction);
+              new Prime.Widgets.Tooltip(dialog.element.queryFirst('p'));
+            })
+            .initialize()
+            .open('ajax-dialog-response.html');
+        Prime.Utils.stopEvent(e);
+      };
+
+      Prime.Document.queryById('ajax-dialog-non-dismissible-button').addEventListener('click', openNonDismissibleFunction);
+
       var htmlDialog = new Prime.Widgets.HTMLDialog(Prime.Document.queryById('html-dialog'));
       Prime.Document.queryById('html-dialog-button').addEventListener('click', function() {
         htmlDialog.open();
@@ -321,6 +335,7 @@
 
   <div id="ajax-dialog-container">
     <a href="#" id="ajax-dialog-button">Open AJAX dialog</a>
+    <a href="#" id="ajax-dialog-non-dismissible-button">Open Non-Dismissible AJAX dialog</a>
   </div>
 
   <a href="#" id="html-dialog-button">Open HTML dialog</a>

--- a/src/test/html/test-functional.html
+++ b/src/test/html/test-functional.html
@@ -196,7 +196,8 @@
       Prime.Document.queryById('ajax-dialog-button').addEventListener('click', openFunction);
 
       var openNonDismissibleFunction = function(e) {
-        new Prime.Widgets.AJAXDialog(false)
+        new Prime.Widgets.AJAXDialog()
+            .withDismissible(false)
             .withCallback(function(dialog) {
               dialog.element.queryFirst('a.dialog-button').addEventListener('click', openNonDismissibleFunction);
               new Prime.Widgets.Tooltip(dialog.element.queryFirst('p'));


### PR DESCRIPTION
**Issue**:
- https://github.com/FusionAuth/fusionauth-issues/issues/903
- https://github.com/FusionAuth/fusionauth-issues/issues/1784

**Problems**:
-Modals require mouse movement to close
-Paste doesn't work with admin UI "Authorized redirect URLs"
-Additionally, tab loses your input entry
-karma server wasn't cleanly exiting and failing tests

**Solution**:
-Allow ajax modals to be closed with escape key or clicking off the modal
-Handle paste and tab in Searcher component
-fix annoying karma callback syntax
